### PR TITLE
Disable security in Chrome

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -132,7 +132,12 @@ module.exports = exports = (options)=>
 
     var driver = webdriverio.remote({
       desiredCapabilities: {
-        browserName: 'chrome'
+        browserName: 'chrome',
+        chromeOptions: {
+          args: [
+            'disable-web-security',
+          ],
+        },
       },
       services: ['selenium-standalone']
     }).init().on('error', page_error).url(options.url).then(function () {


### PR DESCRIPTION
Thanks for clickmonkey! It looks like a promising tool, but to get it to work at all on our app I had to pass Chrome the `--disable-web-security` option, otherwise the fact that the browser is looking at clickmonkey's proxy on localhost but content is coming from our app falls foul of the same-origin policy.